### PR TITLE
Use arrays instead of vectors for custom animation data

### DIFF
--- a/src/saturn/saturn_animations.h
+++ b/src/saturn/saturn_animations.h
@@ -15,8 +15,8 @@ extern std::string current_canim_author;
 extern bool current_canim_looping;
 extern int current_canim_length;
 extern int current_canim_nodes;
-extern s16 current_canim_values[99999];
-extern u16 current_canim_indices[99999];
+extern std::vector<s16> current_canim_values;
+extern std::vector<u16> current_canim_indices;
 
 extern std::vector<std::string> canim_array;
 extern std::string canim_directory;


### PR DESCRIPTION
The `current_canim_indices` and `current_canim_values` variables only store a maximum of [99999](https://github.com/Llennpie/Saturn/blob/d8ec6b996ec44fc89878e5b46373e2231b9c0ba5/src/saturn/saturn_animations.cpp#L75-L76) elements, which isn't enough even for the one custom animation that currently comes with Saturn.

For now, we'll use vectors instead of arrays to store both the custom animation's indices and values. However, it may be possible to entirely rewrite the way the animations are loaded in the future.