### PR TITLE
Use arrays instead of vectors for custom animation data

### DIFF
--- a/src/saturn/saturn_animations.cpp
+++ b/src/saturn/saturn_animations.cpp
@@ -72,14 +72,14 @@ string current_canim_author;
 bool current_canim_looping;
 int current_canim_length;
 int current_canim_nodes;
-s16 current_canim_values[99999] = {};
-u16 current_canim_indices[99999] = {};
+std::vector<s16> current_canim_values;
+std::vector<u16> current_canim_indices;
 
 void run_hex_array(Json::Value root, string type) {
-    int i, j;
+    int i;
     string even_one, odd_one;
     for (auto itr : root[type]) {
-        if (i % 2 == 0 || i == 0) {
+        if (i % 2 == 0) {
             // Run on even
             even_one = itr.asString();
             even_one.erase(0, 2);
@@ -94,10 +94,9 @@ void run_hex_array(Json::Value root, string type) {
             ss << std::hex << newValue;
             ss >> output;
             if (type == "values")
-                current_canim_values[j] = (s16)output;
+                current_canim_values.push_back(output);
             else
-                current_canim_indices[j] = (u16)output;
-            j++;
+                current_canim_indices.push_back(output);
         }
         i++;
     }
@@ -150,6 +149,8 @@ void saturn_read_mcomp_animation(string json_path) {
     if (root["looping"].asString() == "false") current_canim_looping = false;
     current_canim_length = std::stoi(root["length"].asString());
     current_canim_nodes = std::stoi(root["nodes"].asString());
+    current_canim_indices.clear();
+    current_canim_values.clear();
     run_hex_array(root, "values");
     run_hex_array(root, "indices");
 
@@ -162,9 +163,9 @@ void saturn_play_custom_animation() {
     gMarioState->animation->targetAnim->unk04 = 0;
     gMarioState->animation->targetAnim->unk06 = 0;
     gMarioState->animation->targetAnim->unk08 = (s16)current_canim_length;
-    gMarioState->animation->targetAnim->unk0A = ANIMINDEX_NUMPARTS(current_canim_indices);
-    gMarioState->animation->targetAnim->values = (const s16*)current_canim_values;
-    gMarioState->animation->targetAnim->index = (const u16*)current_canim_indices;
+    gMarioState->animation->targetAnim->unk0A = current_canim_indices.size() / 6 - 1;
+    gMarioState->animation->targetAnim->values = current_canim_values.data();
+    gMarioState->animation->targetAnim->index = current_canim_indices.data();
     gMarioState->animation->targetAnim->length = 0;
     gMarioState->marioObj->header.gfx.unk38.curAnim = gMarioState->animation->targetAnim;
 }

--- a/src/saturn/saturn_animations.h
+++ b/src/saturn/saturn_animations.h
@@ -15,8 +15,8 @@ extern std::string current_canim_author;
 extern bool current_canim_looping;
 extern int current_canim_length;
 extern int current_canim_nodes;
-extern s16 current_canim_values[99999];
-extern u16 current_canim_indices[99999];
+extern std::vector<s16> current_canim_values;
+extern std::vector<u16> current_canim_indices;
 
 extern std::vector<std::string> canim_array;
 extern std::string canim_directory;


### PR DESCRIPTION
The `current_canim_indices` and `current_canim_values` variables only store a maximum of [99999](https://github.com/Llennpie/Saturn/blob/d8ec6b996ec44fc89878e5b46373e2231b9c0ba5/src/saturn/saturn_animations.cpp#L75-L76) elements, which isn't enough even for the one custom animation that currently comes with Saturn.

For now, we'll use vectors instead of arrays to store both the custom animation's indices and values. However, it may be possible to entirely rewrite the way the animations are loaded in the future.