### PR TITLE
Fix dangling pointer references in `saturn_bind_texture`

### DIFF
--- a/src/saturn/saturn_textures.cpp
+++ b/src/saturn/saturn_textures.cpp
@@ -182,19 +182,13 @@ const void* saturn_bind_texture(const void* input) {
     }
 
     if (show_vmario_emblem) {
-        if (texName == "actors/mario/no_m.rgba16") {
-            outputTexture = string("actors/mario/mario_logo.rgba16").c_str();
-            const void* output = static_cast<const void*>(outputTexture);
-            return output;
-        }
+        if (texName == "actors/mario/no_m.rgba16")
+            return "actors/mario/mario_logo.rgba16";
     }
 
     if (gCurrLevelNum == LEVEL_SA && use_color_background) {
-        if (texName.find("textures/skybox_tiles/") != string::npos) {
-            outputTexture = string("textures/saturn/white.rgba16").c_str();
-            const void* output = static_cast<const void*>(outputTexture);
-            return output;
-        }
+        if (texName.find("textures/skybox_tiles/") != string::npos)
+            return "textures/saturn/white.rgba16";
     }
 
     return input;


### PR DESCRIPTION
This pull request introduces [`39fa023`](https://github.com/integerbang/Saturn/commit/39fa0239ba33f3f2effb1e6911d56dde6cad5983), which fixes the two dangling pointer references in [`saturn_bind_texture`](https://github.com/Llennpie/Saturn/blob/5affbbf42f6e824a59c64d18dcd9193340acf3fc/src/saturn/saturn_textures.cpp#L146-L201). Without this change, Saturn will fail to show the background used by the course replacing the Secret Aquarium and the emblem on Mario's hat.

The commit's summary is prefixed with the affected function's name to reflect what part of Saturn was changed.